### PR TITLE
디자인 회의 의견들 반영

### DIFF
--- a/app/src/main/java/com/seoultech/fooddeuk/MainActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/MainActivity.kt
@@ -26,32 +26,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun tmpButtonsClickListener() {
-        binding.tmpGuideButtonCustomer.setOnClickListener {
-            val intent = Intent(this, IntroCustomerActivity::class.java)
-            startActivity(intent)
-        }
-        binding.tmpGuideButtonCeo.setOnClickListener {
-            val intent = Intent(this, IntroCEOActivity::class.java)
-            startActivity(intent)
-        }
         binding.tmpWriteReview.setOnClickListener {
             val intent = Intent(this, InputStoreActivity::class.java)
             startActivity(intent)
         }
-        binding.tmpMap.setOnClickListener {
-            val intent = Intent(this, MapActivity::class.java)
-            startActivity(intent)
-        }
-        binding.tmpTruckDetail.setOnClickListener {
-            val intent = Intent(this, TruckDetailActivity::class.java)
-            startActivity(intent)
-        }
         binding.tmpCheckReview.setOnClickListener {
             val intent = Intent(this, InputReviewActivity::class.java)
-            startActivity(intent)
-        }
-        binding.tmpMyPage.setOnClickListener {
-            val intent = Intent(this, MyPageActivity::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/seoultech/fooddeuk/ceoOnOff/CeoOnOffActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/ceoOnOff/CeoOnOffActivity.kt
@@ -1,5 +1,6 @@
 package com.seoultech.fooddeuk.ceoOnOff
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -7,6 +8,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.BindingAdapter
 import androidx.databinding.BindingConversion
 import androidx.databinding.DataBindingUtil
+import com.seoultech.fooddeuk.MainActivity
 import com.seoultech.fooddeuk.R
 import com.seoultech.fooddeuk.databinding.ActivityCeoOnOffBinding
 
@@ -19,7 +21,7 @@ class CeoOnOffActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_ceo_on_off)
 
         init()
-        setOnClickOffToggleButtonListener()
+        setOnClickListeners()
     }
 
     private fun init() {
@@ -27,7 +29,7 @@ class CeoOnOffActivity : AppCompatActivity() {
         binding.onOrOff = true
     }
 
-    private fun setOnClickOffToggleButtonListener() {
+    private fun setOnClickListeners() {
         binding.layoutOnOffToggle.btnOn.setOnClickListener {
             binding.layoutOnOffToggle.onOrOff = true
             binding.onOrOff = true
@@ -35,6 +37,10 @@ class CeoOnOffActivity : AppCompatActivity() {
         binding.layoutOnOffToggle.btnOff.setOnClickListener {
             binding.layoutOnOffToggle.onOrOff = false
             binding.onOrOff = false
+        }
+        binding.btnOnSettingSave.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/com/seoultech/fooddeuk/intro/IntroCEOActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/intro/IntroCEOActivity.kt
@@ -20,10 +20,10 @@ class IntroCEOActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
-        val tab = binding.tabIndication
-        val viewPager = binding.screenViewPager
+        val tab = binding.tlIndication
+        val viewPager = binding.vpScreen
         val skip = binding.btnSkip
-        val btnStarted = binding.btnStarted
+        val btnStarted = binding.btnStart
 
         //fill list screen
         var mList : MutableList<ScreenItem> = mutableListOf()
@@ -58,7 +58,7 @@ class IntroCEOActivity : AppCompatActivity() {
 
         //setup viewpager
         val introViewPagerAdapter = IntroViewPagerAdapter(this, mList)
-        binding.screenViewPager.adapter = introViewPagerAdapter
+        binding.vpScreen.adapter = introViewPagerAdapter
 
         //setup tablayout with viewpager
         TabLayoutMediator(tab, viewPager) { tab, position ->
@@ -85,22 +85,18 @@ class IntroCEOActivity : AppCompatActivity() {
 
         //intro skip
         skip.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-            finish()
+            finish() // 액티비티 백스택 계산해보면 로그인 화면으로 돌아감
         }
 
         //start
         btnStarted.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-            finish()
+            finish() // 액티비티 백스택 계산해보면 로그인 화면으로 돌아감
         }
     }
 
     private fun loadLastScreen() {
-        val btnStarted = binding.btnStarted
-        val tab = binding.tabIndication
+        val btnStarted = binding.btnStart
+        val tab = binding.tlIndication
         val skip = binding.btnSkip
         val btnAnim = AnimationUtils.loadAnimation(applicationContext, R.anim.btn_animation)
         btnStarted.visibility = View.VISIBLE
@@ -110,8 +106,8 @@ class IntroCEOActivity : AppCompatActivity() {
     }
 
     private fun loadTab() {
-        val btnStarted = binding.btnStarted
-        val tab = binding.tabIndication
+        val btnStarted = binding.btnStart
+        val tab = binding.tlIndication
         val skip = binding.btnSkip
         tab.visibility = View.VISIBLE
         skip.visibility = View.VISIBLE

--- a/app/src/main/java/com/seoultech/fooddeuk/intro/IntroCustomerActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/intro/IntroCustomerActivity.kt
@@ -22,10 +22,10 @@ class IntroCustomerActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
-        val tab = binding.tabIndication
-        val viewPager = binding.screenViewPager
+        val tab = binding.tlIndication
+        val viewPager = binding.vpScreen
         val skip = binding.btnSkip
-        val btnStarted = binding.btnStarted
+        val btnStarted = binding.btnStart
 
         //fill list screen
         var mList : MutableList<ScreenItem> = mutableListOf()
@@ -60,7 +60,7 @@ class IntroCustomerActivity : AppCompatActivity() {
 
         //setup viewpager
         val introViewPagerAdapter = IntroViewPagerAdapter(this, mList)
-        binding.screenViewPager.adapter = introViewPagerAdapter
+        binding.vpScreen.adapter = introViewPagerAdapter
 
         //setup tablayout with viewpager
         TabLayoutMediator(tab, viewPager) { tab, position ->
@@ -87,22 +87,18 @@ class IntroCustomerActivity : AppCompatActivity() {
 
         //intro skip
         skip.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-            finish()
+            finish() // 액티비티 백스택 계산해보면 로그인 화면으로 돌아감
         }
 
         //start
         btnStarted.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-            finish()
+            finish() // 액티비티 백스택 계산해보면 로그인 화면으로 돌아감
         }
     }
 
     private fun loadLastScreen() {
-        val btnStarted = binding.btnStarted
-        val tab = binding.tabIndication
+        val btnStarted = binding.btnStart
+        val tab = binding.tlIndication
         val skip = binding.btnSkip
         val btnAnim = AnimationUtils.loadAnimation(applicationContext, R.anim.btn_animation)
         btnStarted.visibility = View.VISIBLE
@@ -112,8 +108,8 @@ class IntroCustomerActivity : AppCompatActivity() {
     }
 
     private fun loadTab() {
-        val btnStarted = binding.btnStarted
-        val tab = binding.tabIndication
+        val btnStarted = binding.btnStart
+        val tab = binding.tlIndication
         val skip = binding.btnSkip
         tab.visibility = View.VISIBLE
         skip.visibility = View.VISIBLE

--- a/app/src/main/java/com/seoultech/fooddeuk/login/LoginActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/login/LoginActivity.kt
@@ -25,9 +25,13 @@ class LoginActivity : AppCompatActivity() {
 
     private fun setLoginIceBreakingImage() {
         when (getUserType()) {
-            UserType.CEO.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_ceo_login_logo)
-            UserType.CUSTOMER.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_customer_login_logo)
+            UserType.CEO.name -> binding.userType = UserType.CEO.name
+            UserType.CUSTOMER.name -> binding.userType = UserType.CUSTOMER.name
         }
+//        when (userType) {
+//            UserType.CEO.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_ceo_login_logo)
+//            UserType.CUSTOMER.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_customer_login_logo)
+//        }
     }
 
     private fun showSignUpView() {

--- a/app/src/main/java/com/seoultech/fooddeuk/login/LoginActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/login/LoginActivity.kt
@@ -3,10 +3,13 @@ package com.seoultech.fooddeuk.login
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
 import com.seoultech.fooddeuk.MainActivity
 import com.seoultech.fooddeuk.ceoOnOff.CeoOnOffActivity
 import com.seoultech.fooddeuk.R
 import com.seoultech.fooddeuk.databinding.ActivitySignInBinding
+import com.seoultech.fooddeuk.map.MapActivity
 import com.seoultech.fooddeuk.signUp.SignUpActivity
 
 class LoginActivity : AppCompatActivity() {
@@ -19,8 +22,7 @@ class LoginActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         setLoginIceBreakingImage()
-        setOnClickLoginButtonListener()
-        showSignUpView()
+        setOnClickListeners()
     }
 
     private fun setLoginIceBreakingImage() {
@@ -28,20 +30,9 @@ class LoginActivity : AppCompatActivity() {
             UserType.CEO.name -> binding.userType = UserType.CEO.name
             UserType.CUSTOMER.name -> binding.userType = UserType.CUSTOMER.name
         }
-//        when (userType) {
-//            UserType.CEO.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_ceo_login_logo)
-//            UserType.CUSTOMER.name -> binding.ivIceBreaking.setImageResource(R.drawable.ic_customer_login_logo)
-//        }
     }
 
-    private fun showSignUpView() {
-        binding.tvGoSignUp.setOnClickListener {
-            val intent = Intent(this, SignUpActivity::class.java)
-            startActivity(intent)
-        }
-    }
-
-    private fun setOnClickLoginButtonListener() {
+    private fun setOnClickListeners() {
         binding.btnLogin.setOnClickListener {
             when (getUserType()) {
                 UserType.CEO.name -> {
@@ -50,11 +41,22 @@ class LoginActivity : AppCompatActivity() {
                     finish()
                 }
                 UserType.CUSTOMER.name -> {
-                    val intent = Intent(this, MainActivity::class.java)
+                    val intent = Intent(this, MapActivity::class.java)
                     startActivity(intent)
                     finish()
                 }
             }
+        }
+
+        binding.tvGoSignUp.setOnClickListener {
+            val intent = Intent(this, SignUpActivity::class.java).apply {
+                putExtra("USER_TYPE", getUserType())
+            }
+            startActivity(intent)
+        }
+
+        binding.ivBackArrow.setOnClickListener {
+            finish()
         }
     }
 

--- a/app/src/main/java/com/seoultech/fooddeuk/login/LoginBindingAdapter.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/login/LoginBindingAdapter.kt
@@ -1,0 +1,16 @@
+package com.seoultech.fooddeuk.login
+
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import com.seoultech.fooddeuk.R
+
+object LoginBindingAdapter {
+    @BindingAdapter("setLoginLogo")
+    fun setLoginLogo(view: ImageView, userType: String) {
+        if (userType == UserType.CEO.name) {
+            view.setImageResource(R.drawable.ic_ceo_login_logo)
+        } else if (userType == UserType.CUSTOMER.name) {
+            view.setImageResource(R.drawable.ic_customer_login_logo)
+        }
+    }
+}

--- a/app/src/main/java/com/seoultech/fooddeuk/login/LoginBindingAdapter.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/login/LoginBindingAdapter.kt
@@ -6,6 +6,7 @@ import com.seoultech.fooddeuk.R
 
 object LoginBindingAdapter {
     @BindingAdapter("setLoginLogo")
+    @JvmStatic
     fun setLoginLogo(view: ImageView, userType: String) {
         if (userType == UserType.CEO.name) {
             view.setImageResource(R.drawable.ic_ceo_login_logo)

--- a/app/src/main/java/com/seoultech/fooddeuk/map/MapActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/map/MapActivity.kt
@@ -2,16 +2,21 @@ package com.seoultech.fooddeuk.map
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat.startActivity
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.seoultech.fooddeuk.R
 import com.seoultech.fooddeuk.databinding.ActivityMapBinding
+import com.seoultech.fooddeuk.detail.TruckDetailActivity
+import com.seoultech.fooddeuk.mypage.MyPageActivity
+import com.seoultech.fooddeuk.signUp.SignUpActivity
 import com.seoultech.fooddeuk.util.AndroidPermissionManager
 import net.daum.mf.map.api.MapPOIItem
 import net.daum.mf.map.api.MapPoint
@@ -31,6 +36,8 @@ class MapActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMapBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setOnClickListeners()
     }
 
     override fun onResume() {
@@ -86,25 +93,30 @@ class MapActivity : AppCompatActivity() {
         }
     }
 
-    class MarkerEventListener(val context: Context): MapView.POIItemEventListener {
-        override fun onPOIItemSelected(p0: MapView?, p1: MapPOIItem?) {
-            Toast.makeText(context, "${p1?.itemName} 눌림", Toast.LENGTH_SHORT).show()
+    private fun setOnClickListeners() {
+        binding.fabCategoryFilter.setOnClickListener {
+            Toast.makeText(this, "눌림", Toast.LENGTH_SHORT).show()
         }
+        binding.fabMypage.setOnClickListener {
+            val intent = Intent(this, MyPageActivity::class.java)
+            startActivity(intent)
+        }
+    }
+
+    class MarkerEventListener(val context: Context): MapView.POIItemEventListener {
+        override fun onPOIItemSelected(p0: MapView?, p1: MapPOIItem?) { }
 
         override fun onCalloutBalloonOfPOIItemTouched(p0: MapView?, p1: MapPOIItem?) {
-            TODO("Not yet implemented")
+            val intent = Intent(context, TruckDetailActivity::class.java)
+            context.startActivity(intent)
         }
 
         override fun onCalloutBalloonOfPOIItemTouched(
             p0: MapView?,
             p1: MapPOIItem?,
             p2: MapPOIItem.CalloutBalloonButtonType?
-        ) {
-            TODO("Not yet implemented")
-        }
+        ) { }
 
-        override fun onDraggablePOIItemMoved(p0: MapView?, p1: MapPOIItem?, p2: MapPoint?) {
-            TODO("Not yet implemented")
-        }
+        override fun onDraggablePOIItemMoved(p0: MapView?, p1: MapPOIItem?, p2: MapPoint?) { }
     }
 }

--- a/app/src/main/java/com/seoultech/fooddeuk/signUp/SignUpActivity.kt
+++ b/app/src/main/java/com/seoultech/fooddeuk/signUp/SignUpActivity.kt
@@ -1,8 +1,14 @@
 package com.seoultech.fooddeuk.signUp
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.seoultech.fooddeuk.R
 import com.seoultech.fooddeuk.databinding.ActivitySignUpBinding
+import com.seoultech.fooddeuk.intro.IntroCEOActivity
+import com.seoultech.fooddeuk.intro.IntroCustomerActivity
+import com.seoultech.fooddeuk.login.UserType
 
 class SignUpActivity : AppCompatActivity() {
 
@@ -11,7 +17,30 @@ class SignUpActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySignUpBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
+
+        setOnClickListeners()
     }
+
+    private fun setOnClickListeners() {
+        binding.ivBackArrow.setOnClickListener {
+            finish()
+        }
+        binding.btnSignUpComplete.setOnClickListener {
+            when (getUserType()) {
+                UserType.CEO.name -> {
+                    val intent = Intent(this, IntroCEOActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+                UserType.CUSTOMER.name -> {
+                    val intent = Intent(this, IntroCustomerActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+            }
+        }
+    }
+
+    private fun getUserType() = intent.getStringExtra("USER_TYPE")
 }

--- a/app/src/main/res/drawable/ic_floating_category_filter.xml
+++ b/app/src/main/res/drawable/ic_floating_category_filter.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/food_deuk_text_b"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4.25,5.61C6.27,8.2 10,13 10,13v6c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-6c0,0 3.72,-4.8 5.74,-7.39C20.25,4.95 19.78,4 18.95,4H5.04C4.21,4 3.74,4.95 4.25,5.61z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_floating_mypage.xml
+++ b/app/src/main/res/drawable/ic_floating_mypage.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="17dp"
+    android:viewportWidth="17"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M8.5,8C10.433,8 12,6.433 12,4.5C12,2.567 10.433,1 8.5,1C6.567,1 5,2.567 5,4.5C5,6.433 6.567,8 8.5,8Z"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#666666"/>
+  <path
+      android:pathData="M8.5,10C4.3579,10 1,12.6863 1,16H16C16,12.6863 12.6421,10 8.5,10Z"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#666666"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/activity_intro_ceo.xml
+++ b/app/src/main/res/layout/activity_intro_ceo.xml
@@ -8,7 +8,7 @@
     tools:context=".intro.IntroCEOActivity">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btnSkip"
+        android:id="@+id/btn_skip"
         android:layout_width="50dp"
         android:layout_height="15dp"
         android:layout_marginTop="33dp"
@@ -21,7 +21,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/screenViewPager"
+        android:id="@+id/vp_screen"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginBottom="73dp"
@@ -29,12 +29,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnSkip">
+        app:layout_constraintTop_toBottomOf="@+id/btn_skip">
 
     </androidx.viewpager2.widget.ViewPager2>
 
     <Button
-        android:id="@+id/btnStarted"
+        android:id="@+id/btn_start"
         android:layout_width="292dp"
         android:layout_height="40dp"
         android:layout_marginBottom="33dp"
@@ -49,7 +49,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tabIndication"
+        android:id="@+id/tl_indication"
         android:layout_width="60dp"
         android:layout_height="14dp"
         android:layout_marginBottom="33dp"

--- a/app/src/main/res/layout/activity_intro_customer.xml
+++ b/app/src/main/res/layout/activity_intro_customer.xml
@@ -8,7 +8,7 @@
     tools:context=".intro.IntroCustomerActivity">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btnSkip"
+        android:id="@+id/btn_skip"
         android:layout_width="50dp"
         android:layout_height="15dp"
         android:layout_marginTop="33dp"
@@ -21,7 +21,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/screenViewPager"
+        android:id="@+id/vp_screen"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginBottom="73dp"
@@ -29,12 +29,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnSkip">
+        app:layout_constraintTop_toBottomOf="@+id/btn_skip">
 
     </androidx.viewpager2.widget.ViewPager2>
 
     <Button
-        android:id="@+id/btnStarted"
+        android:id="@+id/btn_start"
         android:layout_width="292dp"
         android:layout_height="40dp"
         android:layout_marginBottom="33dp"
@@ -49,7 +49,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tabIndication"
+        android:id="@+id/tl_indication"
         android:layout_width="60dp"
         android:layout_height="14dp"
         android:layout_marginBottom="33dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,51 +7,14 @@
     tools:context=".signUp.SignUpActivity">
 
     <Button
-        android:id="@+id/tmp_guide_button_customer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="앱 가이드뷰(손님용)로 임시 이동 버튼"
-        android:layout_marginTop="50dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.497"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/tmp_guide_button_ceo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="앱 가이드뷰(사장님용)로 임시 이동 버튼"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_guide_button_customer" />
-
-    <Button
         android:id="@+id/tmp_write_review"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="100dp"
         android:text="리뷰 작성 뷰로 임시 이동 버튼"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_guide_button_ceo" />
-
-    <Button
-        android:id="@+id/tmp_map"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_write_review"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="지도 뷰로 임시 이동 버튼"/>
-
-    <Button
-        android:id="@+id/tmp_truck_detail"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="트럭 상세보기 임시 이동"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_map" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/tmp_check_review"
@@ -61,16 +24,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_truck_detail" />
-
-    <Button
-        android:id="@+id/tmp_my_page"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="마이 페이지 임시 이동 버튼"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tmp_truck_detail" />
+        app:layout_constraintTop_toBottomOf="@+id/tmp_write_review" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -16,32 +16,29 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- 상단 주소 부분 -->
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_address"
-        android:layout_width="0dp"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_category_filter"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:enabled="false"
-        android:layout_marginTop="29dp"
-        android:layout_marginStart="42dp"
-        android:layout_marginEnd="42dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="126dp"
+        android:backgroundTint="@color/white"
+        app:fabSize="mini"
+        app:srcCompat="@drawable/ic_floating_category_filter"
+        app:borderWidth="@null"
         app:layout_constraintEnd_toEndOf="parent"
-        app:hintEnabled="false"
-        app:boxBackgroundColor="@color/white"
-        app:boxStrokeWidth="0dp"
-        app:boxStrokeWidthFocused="0dp"
-        style="@style/MapAddressTextInputLayoutStyle">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/tiet_address"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingVertical="21dp"
-            android:text="서울특별시 노원구 공릉동 123-5"
-            android:textSize="17sp"
-            android:textColor="@color/food_deuk_text_a"
-            android:gravity="center" />
-    </com.google.android.material.textfield.TextInputLayout>
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_mypage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="14dp"
+        android:backgroundTint="@color/white"
+        app:fabSize="mini"
+        app:srcCompat="@drawable/ic_floating_mypage"
+        app:borderWidth="@null"
+        app:layout_constraintTop_toBottomOf="@+id/fab_category_filter"
+        app:layout_constraintStart_toStartOf="@+id/fab_category_filter" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -20,7 +20,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="34dp"
             android:layout_marginStart="20dp"
-            app:setLoginLogo="@{userType}"
+            android:src="@drawable/ic_back_arrow"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
 
@@ -31,8 +31,7 @@
             android:layout_height="66dp"
             android:layout_marginStart="44dp"
             android:layout_marginTop="152dp"
-            android:contentDescription="로그인 인사말 로고"
-            android:src="@{userType.equals('CEO')}"
+            app:setLoginLogo="@{userType}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_ceo_login_logo"/>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -1,111 +1,132 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".login.LoginActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- 로그인 인사말 로고 부분 -->
-    <ImageView
-        android:id="@+id/iv_ice_breaking"
-        android:layout_width="112dp"
-        android:layout_height="66dp"
-        android:layout_marginTop="156dp"
-        android:layout_marginStart="45dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:src="@drawable/ic_ceo_login_logo"
-        android:contentDescription="로그인 인사말 로고" />
+    <data>
+        <variable
+            name="userType"
+            type="String" />
+    </data>
 
-    <!-- 아이디 입력 부분 -->
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_id"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="110dp"
-        android:layout_marginStart="45dp"
-        android:layout_marginEnd="45dp"
-        app:layout_constraintTop_toBottomOf="@+id/iv_ice_breaking"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:hintEnabled="false"
-        style="@style/SignInTextInputLayoutStyle">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_id"
-            android:layout_width="match_parent"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".login.LoginActivity">
+
+        <ImageView
+            android:id="@+id/iv_back_arrow"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:hint="아이디"
-            android:textSize="16sp"
-            android:textColorHint="@color/food_deuk_text_d"
-            android:maxLines="1"/>
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="34dp"
+            android:layout_marginStart="20dp"
+            app:setLoginLogo="@{userType}"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
 
-    <!-- 비밀번호 입력 부분 -->
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_password"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="45dp"
-        android:layout_marginEnd="45dp"
-        app:layout_constraintTop_toBottomOf="@+id/til_id"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:hintEnabled="false"
-        app:endIconMode="password_toggle"
-        style="@style/SignInTextInputLayoutStyle">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_password"
-            android:layout_width="match_parent"
+        <!-- 로그인 인사말 로고 부분 -->
+        <ImageView
+            android:id="@+id/iv_ice_breaking"
+            android:layout_width="112dp"
+            android:layout_height="66dp"
+            android:layout_marginStart="44dp"
+            android:layout_marginTop="152dp"
+            android:contentDescription="로그인 인사말 로고"
+            android:src="@{userType.equals('CEO')}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_ceo_login_logo"/>
+
+        <!-- 아이디 입력 부분 -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_id"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:hint="비밀번호"
-            android:inputType="textPassword"
-            android:textSize="16sp"
-            android:textColorHint="@color/food_deuk_text_d"
-            android:maxLines="1" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="110dp"
+            android:layout_marginStart="45dp"
+            android:layout_marginEnd="45dp"
+            app:layout_constraintTop_toBottomOf="@+id/iv_ice_breaking"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:hintEnabled="false"
+            style="@style/SignInTextInputLayoutStyle">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_id"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="아이디"
+                android:textSize="16sp"
+                android:textColorHint="@color/food_deuk_text_d"
+                android:maxLines="1"/>
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <!-- 로그인 버튼 -->
-    <Button
-        android:id="@+id/btn_login"
-        android:layout_width="0dp"
-        android:layout_height="64dp"
-        android:layout_marginTop="18dp"
-        android:layout_marginStart="45dp"
-        android:layout_marginEnd="45dp"
-        android:text="로그인"
-        android:textSize="19sp"
-        android:backgroundTint="@color/food_deuk_text_d"
-        app:layout_constraintTop_toBottomOf="@+id/til_password"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        style="@style/LoginButtonStyle"/>
+        <!-- 비밀번호 입력 부분 -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_password"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginStart="45dp"
+            android:layout_marginEnd="45dp"
+            app:layout_constraintTop_toBottomOf="@+id/til_id"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:hintEnabled="false"
+            app:endIconMode="password_toggle"
+            style="@style/SignInTextInputLayoutStyle">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="비밀번호"
+                android:inputType="textPassword"
+                android:textSize="16sp"
+                android:textColorHint="@color/food_deuk_text_d"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <!-- 아이디/비밀번호 찾기 부분 -->
-    <TextView
-        android:id="@+id/tv_find_id_password"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:text="아이디 ‧ 비밀번호 찾기"
-        android:textSize="15sp"
-        android:textColor="@color/food_deuk_text_b"
-        app:layout_constraintTop_toBottomOf="@+id/btn_login"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        <!-- 로그인 버튼 -->
+        <Button
+            android:id="@+id/btn_login"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_marginTop="18dp"
+            android:layout_marginStart="45dp"
+            android:layout_marginEnd="45dp"
+            android:text="로그인"
+            android:textSize="19sp"
+            android:backgroundTint="@color/food_deuk_text_d"
+            app:layout_constraintTop_toBottomOf="@+id/til_password"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            style="@style/LoginButtonStyle"/>
 
-    <!-- 회원가입하기 부분 -->
-    <TextView
-        android:id="@+id/tv_go_sign_up"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="40dp"
-        android:text="@string/go_sign_up"
-        android:textSize="15sp"
-        android:textColor="@color/food_deuk_main_color"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        <!-- 아이디/비밀번호 찾기 부분 -->
+        <TextView
+            android:id="@+id/tv_find_id_password"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="아이디 ‧ 비밀번호 찾기"
+            android:textSize="15sp"
+            android:textColor="@color/food_deuk_text_b"
+            app:layout_constraintTop_toBottomOf="@+id/btn_login"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <!-- 회원가입하기 부분 -->
+        <TextView
+            android:id="@+id/tv_go_sign_up"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="40dp"
+            android:text="@string/go_sign_up"
+            android:textSize="15sp"
+            android:textColor="@color/food_deuk_main_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -2,24 +2,24 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".MainActivity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
     <!-- 뒤로가기 화살표 -->
     <ImageView
-        android:id="@+id/ivBack"
+        android:id="@+id/iv_back_arrow"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:layout_marginTop="45dp"
         android:layout_marginStart="26dp"
-        android:src="@drawable/ic_back_arrow" />
+        android:src="@drawable/ic_back_arrow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <!-- 회원가입 타이틀 -->
     <TextView
-        android:id="@+id/tvStarReviewTitle"
+        android:id="@+id/tv_star_review_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -32,11 +32,11 @@
 
     <!-- 아이디 입력 부분 -->
     <TextView
-        android:id="@+id/id_title_text_view"
+        android:id="@+id/tv_id_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tvStarReviewTitle"
+        app:layout_constraintTop_toBottomOf="@id/tv_star_review_title"
         android:layout_marginStart="45dp"
         android:layout_marginTop="61dp"
         android:text="아이디"
@@ -44,18 +44,18 @@
         android:textSize="16sp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/id_text_input_layout"
+        android:id="@+id/til_id"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@+id/id_title_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/id_title_text_view"
-        app:layout_constraintEnd_toStartOf="@+id/check_redundancy_button"
+        app:layout_constraintStart_toStartOf="@+id/tv_id_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_id_title"
+        app:layout_constraintEnd_toStartOf="@+id/btn_check_redundancy"
         app:layout_constraintHorizontal_weight="70"
         android:layout_marginTop="2dp"
         app:boxBackgroundColor="@null"
         app:hintEnabled="false">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/id_text_input_edit_text"
+            android:id="@+id/tiet_id"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             style="@style/SignUpEditText"
@@ -63,13 +63,13 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button
-        android:id="@+id/check_redundancy_button"
+        android:id="@+id/btn_check_redundancy"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintStart_toEndOf="@id/id_text_input_layout"
-        app:layout_constraintTop_toTopOf="@id/id_text_input_layout"
+        app:layout_constraintStart_toEndOf="@id/til_id"
+        app:layout_constraintTop_toTopOf="@id/til_id"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="@id/id_text_input_layout"
+        app:layout_constraintBottom_toBottomOf="@id/til_id"
         app:layout_constraintHorizontal_weight="30"
         android:layout_marginEnd="45dp"
         android:layout_marginStart="5dp"
@@ -81,11 +81,11 @@
 
     <!-- 비밀번호 입력 부분 -->
     <TextView
-        android:id="@+id/pw_title_text_view"
+        android:id="@+id/tv_pw_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/id_text_input_layout"
+        app:layout_constraintTop_toBottomOf="@+id/til_id"
         android:layout_marginStart="45dp"
         android:layout_marginTop="33dp"
         android:text="비밀번호"
@@ -93,18 +93,18 @@
         android:textSize="16sp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/pw_text_input_layout"
+        android:id="@+id/til_pw"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@+id/pw_title_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/pw_title_text_view"
+        app:layout_constraintStart_toStartOf="@+id/tv_pw_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_pw_title"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="2dp"
         android:layout_marginEnd="45dp"
         app:boxBackgroundColor="@null"
         app:hintEnabled="false">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/pw_text_input_edit_text"
+            android:id="@+id/tiet_pw"
             style="@style/SignUpEditText"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -113,11 +113,11 @@
 
     <!-- 비밀번호 확인 입력 부분 -->
     <TextView
-        android:id="@+id/pw_confirm_title_text_view"
+        android:id="@+id/tv_pw_confirm_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/pw_text_input_layout"
+        app:layout_constraintTop_toBottomOf="@+id/til_pw"
         android:layout_marginStart="45dp"
         android:layout_marginTop="33dp"
         android:text="비밀번호 확인"
@@ -125,18 +125,18 @@
         android:textSize="16sp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/pw_confirm_text_input_layout"
+        android:id="@+id/til_pw_confirm"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@+id/pw_confirm_title_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/pw_confirm_title_text_view"
+        app:layout_constraintStart_toStartOf="@+id/tv_pw_confirm_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_pw_confirm_title"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="2dp"
         android:layout_marginEnd="45dp"
         app:boxBackgroundColor="@null"
         app:hintEnabled="false">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/pw_confirm_text_input_edit_text"
+            android:id="@+id/tiet_pw_confirm"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             style="@style/SignUpEditText"
@@ -145,11 +145,11 @@
 
     <!-- 닉네임 입력 부분 -->
     <TextView
-        android:id="@+id/nick_name_title_text_view"
+        android:id="@+id/tv_nick_name_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/pw_confirm_text_input_layout"
+        app:layout_constraintTop_toBottomOf="@+id/til_pw_confirm"
         android:layout_marginStart="45dp"
         android:layout_marginTop="33dp"
         android:text="닉네임"
@@ -157,18 +157,18 @@
         android:textSize="16sp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/nick_name_text_input_layou"
+        android:id="@+id/til_nick_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@+id/nick_name_title_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/nick_name_title_text_view"
+        app:layout_constraintStart_toStartOf="@+id/tv_nick_name_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_nick_name_title"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="2dp"
         android:layout_marginEnd="45dp"
         app:boxBackgroundColor="@null"
         app:hintEnabled="false">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/nick_name_text_input_edit_text"
+            android:id="@+id/tiet_nick_name"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             style="@style/SignUpEditText"
@@ -177,11 +177,11 @@
 
     <!-- 휴대전화 번호 -->
     <TextView
-        android:id="@+id/phone_number_title_text_view"
+        android:id="@+id/tv_phone_number_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/nick_name_text_input_layou"
+        app:layout_constraintTop_toBottomOf="@+id/til_nick_name"
         android:layout_marginStart="45dp"
         android:layout_marginTop="33dp"
         android:text="휴대전화 번호"
@@ -189,18 +189,18 @@
         android:textSize="16sp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/phone_number_text_input_layout"
+        android:id="@+id/til_phone_number"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@+id/phone_number_title_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/phone_number_title_text_view"
+        app:layout_constraintStart_toStartOf="@+id/tv_phone_number_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_phone_number_title"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="2dp"
         android:layout_marginEnd="45dp"
         app:boxBackgroundColor="@null"
         app:hintEnabled="false">
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/phone_number_text_input_edit_text"
+            android:id="@+id/tiet_phone_number"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             style="@style/SignUpEditText"
@@ -209,7 +209,7 @@
 
     <!-- 가입하기 버튼 부분 -->
     <Button
-        android:id="@+id/sign_up_complete_button"
+        android:id="@+id/btn_sign_up_complete"
         android:layout_width="0dp"
         android:layout_height="53dp"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,15 +46,6 @@
 
     <style name="LoginButtonStyle" parent="UserTypeSelectButtonStyle"/>
 
-    <style name="MapAddressTextInputLayoutStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-        <item name="boxCornerRadiusTopStart">16dp</item>
-        <item name="boxCornerRadiusTopEnd">16dp</item>
-        <item name="boxCornerRadiusBottomStart">16dp</item>
-        <item name="boxCornerRadiusBottomEnd">16dp</item>
-        <item name="android:paddingTop">0dp</item> <!-- 기본으로 적용된 패딩 제거 -->
-        <item name="android:paddingBottom">0dp</item>
-    </style>
-
     <style name="NoTruckDialogCancleOrOkButtonStyle" parent="Widget.MaterialComponents.Button.UnelevatedButton">
         <item name="cornerRadius">22dp</item>
         <item name="android:insetTop">0dp</item> <!-- 머티리얼 디자인 버튼 기본 마진 제거(레이아웃 <-> 컴포넌트) -->


### PR DESCRIPTION
## 작업 내용
* 로그인 액티비티
  * 뒤로가기 화살표 추가
* 지도 액티비티
  * 상단 주소 보여주는 뷰 제거
  * 마거 위 풍선 버튼 누르면 상세 페이지로 이동
  * 카테고리 필터 / 마이페이지 플로팅 버튼 추가
  * 마이페이지 플로팅 버튼 누르면 마이페이지 액티비티로 전환
* 앱 사용 흐름 의견 반영
  * 사장님 회원가입 완료 -> 사장님 앱 가이드 액티비티 -> 시작하기/건너뛰기 버튼 클릭 -> 로그인 화면으로 돌아가기
  * 손님 회원가입 완료 -> 손님 앱 가이드 액티비티 -> 시작하기/건너뛰기 버튼 클릭 -> 로그인 화면으로 돌아가기
* MainActivity 수정
  * 임시 버튼 필요 없는 것들 제거(적당한 위치에 들어간 버튼들 제거)
  * 사장님 로그인 버튼 -> 오픈 액티비티의 저장하기 버튼 -> MainActivity 나와용
  
## 시연 영상
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/31889335/132094971-c182a6ac-1ceb-40e7-bb93-93161f2d56be.gif)

